### PR TITLE
Exclude google sheets test in coverage

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -5,3 +5,4 @@ lein cloverage \
     --codecov \
     --html \
     --runner :midje
+    --ns-exclude-regex "zero-one.fxl.google-sheets"

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -4,5 +4,5 @@ lein cloverage \
     --fail-threshold 99 \
     --codecov \
     --html \
-    --runner :midje
+    --runner :midje \
     --ns-exclude-regex "zero-one.fxl.google-sheets"


### PR DESCRIPTION
PRs unable to access secrets unless `pull_request_target` is used. This will also give write permissions, causing secrets to be vulnerable to attack - https://securitylab.github.com/research/github-actions-preventing-pwn-requests

Have to configure the github action workflow properly to allow the google sheets tests to be part of CI and yet protect secrets