### PR TITLE
Use cljfmt for style to improve collaboration

### DIFF
--- a/examples/generate_dummy.clj
+++ b/examples/generate_dummy.clj
@@ -97,5 +97,5 @@
               :style {}}))
 
 (fxl/write-xlsx!
-  cells
-  "test/resources/dummy-spreadsheet.xlsx")
+ cells
+ "test/resources/dummy-spreadsheet.xlsx")

--- a/examples/write_to_plain_excel.clj
+++ b/examples/write_to_plain_excel.clj
@@ -12,10 +12,10 @@
 
 (def body-cells
   (flatten
-    (for [[row cost] (map vector (range) costs)]
-      (list
-        {:value (:item cost) :coord {:row (inc row) :col 0} :style {}}
-        {:value (:cost cost) :coord {:row (inc row) :col 1} :style {}}))))
+   (for [[row cost] (map vector (range) costs)]
+     (list
+      {:value (:item cost) :coord {:row (inc row) :col 0} :style {}}
+      {:value (:cost cost) :coord {:row (inc row) :col 1} :style {}}))))
 
 (def total-cells
   (let [row        (count costs)
@@ -24,5 +24,5 @@
      {:value total-cost :coord {:row (+ row 2) :col 1} :style {}}]))
 
 (fxl/write-xlsx!
-  (concat header-cells body-cells total-cells)
-  "examples/spreadsheets/write_to_plain_excel.xlsx")
+ (concat header-cells body-cells total-cells)
+ "examples/spreadsheets/write_to_plain_excel.xlsx")

--- a/examples/write_to_plain_excel_with_helpers.clj
+++ b/examples/write_to_plain_excel_with_helpers.clj
@@ -25,9 +25,9 @@
   (assoc-in cell [:style :horizontal] :center))
 
 (fxl/write-xlsx!
-  (map align-center
-    (fxl/concat-below
-      (map (comp bold highlight) header-cells)
-      (fxl/pad-below body-cells)
-      (map bold total-cells)))
-  "examples/spreadsheets/write_to_plain_excel_with_helpers.xlsx")
+ (map align-center
+      (fxl/concat-below
+       (map (comp bold highlight) header-cells)
+       (fxl/pad-below body-cells)
+       (map bold total-cells)))
+ "examples/spreadsheets/write_to_plain_excel_with_helpers.xlsx")

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,12 @@
                  [org.clojure/math.combinatorics "0.1.6"]]
   :profiles {:dev {:dependencies [[midje "1.9.9"]]
                    :plugins [[lein-ancient "0.7.0"]
-                             [lein-midje "3.2.2"]
-                             [lein-cloverage "1.2.2"]]}
+                             [lein-cljfmt "0.7.0"]
+                             [lein-cloverage "1.2.2"]
+                             [lein-midje "3.2.2"]]
+                   :cljfmt {:split-keypairs-over-multiple-lines?   false
+                            :remove-multiple-non-indenting-spaces? false
+                            :indents {facts [[:inner 0] [:block 1]]
+                                      forv  [[:inner 0] [:block 1]]
+                                      fact  [[:inner 0] [:block 1]]}}}
              :provided {:dependencies [[org.clojure/clojure "1.10.2"]]}})

--- a/scripts/lint-ancient
+++ b/scripts/lint-ancient
@@ -4,6 +4,8 @@ set -euo pipefail
 
 clj-kondo  --lint src test --cache false
 
+lein cljfmt check src test examples
+
 mkdir -p target
 lein ancient
 

--- a/src/zero_one/fxl/alignments.clj
+++ b/src/zero_one/fxl/alignments.clj
@@ -1,6 +1,6 @@
 (ns zero-one.fxl.alignments
   (:import
-    [org.apache.poi.ss.usermodel HorizontalAlignment VerticalAlignment]))
+   [org.apache.poi.ss.usermodel HorizontalAlignment VerticalAlignment]))
 
 (def horizontal-alignments
   {:center           HorizontalAlignment/CENTER

--- a/src/zero_one/fxl/borders.clj
+++ b/src/zero_one/fxl/borders.clj
@@ -1,6 +1,6 @@
 (ns zero-one.fxl.borders
   (:import
-    [org.apache.poi.ss.usermodel BorderStyle]))
+   [org.apache.poi.ss.usermodel BorderStyle]))
 
 (def border-styles
   {:dash_dot            BorderStyle/DASH_DOT

--- a/src/zero_one/fxl/colours.clj
+++ b/src/zero_one/fxl/colours.clj
@@ -1,6 +1,6 @@
 (ns zero-one.fxl.colours
   (:import
-    [org.apache.poi.ss.usermodel IndexedColors]))
+   [org.apache.poi.ss.usermodel IndexedColors]))
 
 (def colours
   {:aqua                  IndexedColors/AQUA

--- a/src/zero_one/fxl/core.clj
+++ b/src/zero_one/fxl/core.clj
@@ -1,12 +1,12 @@
 (ns zero-one.fxl.core
   (:require
-    [clojure.math.combinatorics :refer [cartesian-product]]
-    [zero-one.fxl.alignments :as alignments]
-    [zero-one.fxl.borders :as borders]
-    [zero-one.fxl.colours :as colours]
-    [zero-one.fxl.defaults :as defaults]
-    [zero-one.fxl.read-xlsx :as read-xlsx]
-    [zero-one.fxl.write-xlsx :as write-xlsx]))
+   [clojure.math.combinatorics :refer [cartesian-product]]
+   [zero-one.fxl.alignments :as alignments]
+   [zero-one.fxl.borders :as borders]
+   [zero-one.fxl.colours :as colours]
+   [zero-one.fxl.defaults :as defaults]
+   [zero-one.fxl.read-xlsx :as read-xlsx]
+   [zero-one.fxl.write-xlsx :as write-xlsx]))
 
 ;; Utility Functions
 (defn ->cell [maybe-cell]
@@ -36,9 +36,9 @@
 
 (defn table->cells [table]
   (flatten
-    (for [[row-index row] (zip-with-index table)]
-      (for [[col-index elem] (zip-with-index row)]
-        {:value elem :coord {:row row-index :col col-index}}))))
+   (for [[row-index row] (zip-with-index table)]
+     (for [[col-index elem] (zip-with-index row)]
+       {:value elem :coord {:row row-index :col col-index}}))))
 
 (defn records->table
   ([records]
@@ -75,11 +75,11 @@
          indexed (group-by :coord cells)]
      (forv [i (range (inc (max-row cells)))]
        (into {}
-         (forv [j (range (inc (max-col cells)))
-                :let  [k (nth ks j nil)
-                       v (-> (indexed {:row i :col j}) first :value)]
-                :when (and k v)]
-           (vector k v)))))))
+             (forv [j (range (inc (max-col cells)))
+                    :let  [k (nth ks j nil)
+                           v (-> (indexed {:row i :col j}) first :value)]
+                    :when (and k v)]
+               (vector k v)))))))
 
 ;; Helper Functions: Relative Coords
 (defn- shift-cell [dir shift cell]
@@ -113,8 +113,8 @@
   ([cells] (pad-right 1 cells))
   ([shift cells]
    (concat-right
-     cells
-     [(->cell {:coord {:row 0 :col (dec shift)} :style {}})])))
+    cells
+    [(->cell {:coord {:row 0 :col (dec shift)} :style {}})])))
 
 (defn concat-below
   ([] nil)
@@ -130,14 +130,14 @@
   ([cells] (pad-below 1 cells))
   ([shift cells]
    (concat-below
-     cells
-     [(->cell {:coord {:row (dec shift) :col 0} :style {}})])))
+    cells
+    [(->cell {:coord {:row (dec shift) :col 0} :style {}})])))
 
 (defn pad-table [cells]
   (let [coords    (->> cells (map :coord) set)
         indices   (cartesian-product
-                    (-> cells max-row inc range)
-                    (-> cells max-col inc range))
+                   (-> cells max-row inc range)
+                   (-> cells max-col inc range))
         pad-cells (for [[row col] indices
                         :let  [coord {:row row :col col}]
                         :when (not (contains? coords coord))]

--- a/src/zero_one/fxl/defaults.clj
+++ b/src/zero_one/fxl/defaults.clj
@@ -9,28 +9,27 @@
 (def coord {:row 0 :col 0})
 
 (def style
- {;; Fonts
-  :bold              false,
-  :italic            false,
-  :underline         false,
-  :strikeout         false
-  :font-size         11,
-  :font-name         "Calibri",
-  :font-colour       :black,
+  {;; Fonts
+   :bold              false,
+   :italic            false,
+   :underline         false,
+   :strikeout         false
+   :font-size         11,
+   :font-name         "Calibri",
+   :font-colour       :black,
   ;; Alignments
-  :horizontal        :general,
-  :vertical          :bottom,
+   :horizontal        :general,
+   :vertical          :bottom,
   ;; Borders
-  :bottom-border     {:style :none, :colour :black},
-  :left-border       {:style :none, :colour :black},
-  :right-border      {:style :none, :colour :black},
-  :top-border        {:style :none, :colour :black},
+   :bottom-border     {:style :none, :colour :black},
+   :left-border       {:style :none, :colour :black},
+   :right-border      {:style :none, :colour :black},
+   :top-border        {:style :none, :colour :black},
   ;; Others
-  :background-colour :automatic
-  :data-format       "General"
-  :row-size          15
-  :col-size          8})
-
+   :background-colour :automatic
+   :data-format       "General"
+   :row-size          15
+   :col-size          8})
 
 (def cell
   {:value   value

--- a/src/zero_one/fxl/read_xlsx.clj
+++ b/src/zero_one/fxl/read_xlsx.clj
@@ -1,14 +1,14 @@
 (ns zero-one.fxl.read-xlsx
   (:require
-    [failjure.core :as f]
-    [zero-one.fxl.alignments :as alignments]
-    [zero-one.fxl.borders :as borders]
-    [zero-one.fxl.colours :as colours]
-    [zero-one.fxl.defaults :as defaults])
+   [failjure.core :as f]
+   [zero-one.fxl.alignments :as alignments]
+   [zero-one.fxl.borders :as borders]
+   [zero-one.fxl.colours :as colours]
+   [zero-one.fxl.defaults :as defaults])
   (:import
-    [java.io FileInputStream]
-    [org.apache.poi.xssf.usermodel XSSFWorkbook]
-    [org.apache.poi.ss.usermodel Font]))
+   [java.io FileInputStream]
+   [org.apache.poi.xssf.usermodel XSSFWorkbook]
+   [org.apache.poi.ss.usermodel Font]))
 
 (defn- extract-cell-value [cell]
   (let [cell-type (.. cell getCellType name)]
@@ -35,26 +35,26 @@
 (defn- extract-cell-border-style [cell]
   (let [cell-style (.getCellStyle cell)]
     {:bottom-border
-      {:style (-> cell-style .getBorderBottom borders/border-style-lookup)
-       :colour (-> cell-style .getBottomBorderColor colours/colours-lookup)}
+     {:style (-> cell-style .getBorderBottom borders/border-style-lookup)
+      :colour (-> cell-style .getBottomBorderColor colours/colours-lookup)}
      :left-border
-      {:style (-> cell-style .getBorderLeft borders/border-style-lookup)
-       :colour (-> cell-style .getLeftBorderColor colours/colours-lookup)}
+     {:style (-> cell-style .getBorderLeft borders/border-style-lookup)
+      :colour (-> cell-style .getLeftBorderColor colours/colours-lookup)}
      :right-border
-      {:style (-> cell-style .getBorderRight borders/border-style-lookup)
-       :colour (-> cell-style .getRightBorderColor colours/colours-lookup)}
+     {:style (-> cell-style .getBorderRight borders/border-style-lookup)
+      :colour (-> cell-style .getRightBorderColor colours/colours-lookup)}
      :top-border
-      {:style (-> cell-style .getBorderTop borders/border-style-lookup)
-       :colour (-> cell-style .getTopBorderColor colours/colours-lookup)}}))
+     {:style (-> cell-style .getBorderTop borders/border-style-lookup)
+      :colour (-> cell-style .getTopBorderColor colours/colours-lookup)}}))
 
 (defn- extract-cell-alignment-style [cell]
   (let [cell-style (.getCellStyle cell)]
     {:horizontal (-> cell-style
-                      .getAlignment
-                      alignments/horizontal-alignment-lookup)
-      :vertical  (-> cell-style
-                     .getVerticalAlignment
-                     alignments/vertical-alignment-lookup)}))
+                     .getAlignment
+                     alignments/horizontal-alignment-lookup)
+     :vertical  (-> cell-style
+                    .getVerticalAlignment
+                    alignments/vertical-alignment-lookup)}))
 
 (defn- extract-cell-font-style [workbook cell]
   (let [font-index (-> cell .getCellStyle .getFontIndexAsInt)
@@ -69,32 +69,32 @@
 
 (defn- prune-cell-style [cell-style]
   (into {}
-    (filter
-      (fn [[k v]] (not= v (defaults/style k)))
-      cell-style)))
+        (filter
+         (fn [[k v]] (not= v (defaults/style k)))
+         cell-style)))
 
 (defn- extract-cell-style [workbook cell]
   (let [col-index  (.getColumnIndex cell)
         cell-style (merge
-                      (extract-cell-border-style cell)
-                      (extract-cell-alignment-style cell)
-                      (extract-cell-font-style workbook cell)
-                      {:background-colour (-> cell
-                                              .getCellStyle
-                                              .getFillForegroundColor
-                                              colours/colours-lookup)
-                       :data-format       (-> cell
-                                              .getCellStyle
-                                              .getDataFormatString)
-                       :col-size          (-> cell
-                                              .getSheet
-                                              (.getColumnWidth col-index)
-                                              (/ 256.0)
-                                              int)
-                       :row-size          (-> cell
-                                              .getRow
-                                              .getHeightInPoints
-                                              int)})]
+                    (extract-cell-border-style cell)
+                    (extract-cell-alignment-style cell)
+                    (extract-cell-font-style workbook cell)
+                    {:background-colour (-> cell
+                                            .getCellStyle
+                                            .getFillForegroundColor
+                                            colours/colours-lookup)
+                     :data-format       (-> cell
+                                            .getCellStyle
+                                            .getDataFormatString)
+                     :col-size          (-> cell
+                                            .getSheet
+                                            (.getColumnWidth col-index)
+                                            (/ 256.0)
+                                            int)
+                     :row-size          (-> cell
+                                            .getRow
+                                            .getHeightInPoints
+                                            int)})]
     (prune-cell-style cell-style)))
 
 (defn- extract-poi-cells [workbook]
@@ -140,7 +140,7 @@
   (-> cell .getCellStyle .getFillPattern)
   (-> cell .getCellStyle .getFillBackgroundColor)
   (-> cell .getCellStyle .getFillForegroundColor colours/colours-lookup)
-  (count (map #(.getIndex % ) (vals colours/colours)))
+  (count (map #(.getIndex %) (vals colours/colours)))
   (count colours/colours)
 
   (def cells (-> row .iterator iterator-seq))

--- a/src/zero_one/fxl/specs.clj
+++ b/src/zero_one/fxl/specs.clj
@@ -1,10 +1,10 @@
 (ns zero-one.fxl.specs
   (:require
-    [clojure.spec.alpha :as s]
-    [expound.alpha :as expound]
-    [zero-one.fxl.alignments :refer [horizontal-alignments vertical-alignments]]
-    [zero-one.fxl.borders :refer [border-styles]]
-    [zero-one.fxl.colours :refer [colours]]))
+   [clojure.spec.alpha :as s]
+   [expound.alpha :as expound]
+   [zero-one.fxl.alignments :refer [horizontal-alignments vertical-alignments]]
+   [zero-one.fxl.borders :refer [border-styles]]
+   [zero-one.fxl.colours :refer [colours]]))
 
 ;; Coordinates
 (def max-rows (int 1e5))

--- a/src/zero_one/fxl/write_xlsx.clj
+++ b/src/zero_one/fxl/write_xlsx.clj
@@ -1,16 +1,16 @@
 (ns zero-one.fxl.write-xlsx
   (:require
-    [failjure.core :as f]
-    [zero-one.fxl.alignments :as alignments]
-    [zero-one.fxl.borders :as borders]
-    [zero-one.fxl.colours :as colours]
-    [zero-one.fxl.data-formats :as data-formats]
-    [zero-one.fxl.defaults :as defaults]
-    [zero-one.fxl.specs :as fs])
+   [failjure.core :as f]
+   [zero-one.fxl.alignments :as alignments]
+   [zero-one.fxl.borders :as borders]
+   [zero-one.fxl.colours :as colours]
+   [zero-one.fxl.data-formats :as data-formats]
+   [zero-one.fxl.defaults :as defaults]
+   [zero-one.fxl.specs :as fs])
   (:import
-    (java.io FileOutputStream)
-    (org.apache.poi.xssf.usermodel XSSFWorkbook)
-    (org.apache.poi.ss.usermodel FillPatternType FontUnderline)))
+   (java.io FileOutputStream)
+   (org.apache.poi.xssf.usermodel XSSFWorkbook)
+   (org.apache.poi.ss.usermodel FillPatternType FontUnderline)))
 
 ;; Apache POI Navigation
 (defn- get-or-create-sheet! [cell workbook]
@@ -91,8 +91,8 @@
 (defn- min-size [axis cells]
   (let [coord-key ({:row :row-size :col :col-size} axis)
         sizes     (->> cells
-                        (map (comp coord-key :style))
-                        (filter some?))]
+                       (map (comp coord-key :style))
+                       (filter some?))]
     (if (some #(= % :auto) sizes)
       :auto
       (apply max -1 sizes))))
@@ -104,10 +104,10 @@
 (defn- grouped-min-size [axis cells]
   (let [grouped-cells (group-by #(partial-coord axis %) cells)]
     (into {}
-      (for [[index group] grouped-cells
-            :let [min-axis-size (min-size axis group)]
-            :when (not= -1 min-axis-size)]
-        [index min-axis-size]))))
+          (for [[index group] grouped-cells
+                :let [min-axis-size (min-size axis group)]
+                :when (not= -1 min-axis-size)]
+            [index min-axis-size]))))
 
 ;; Writing to Excel
 (defn build-context! [workbook cells]
@@ -146,7 +146,7 @@
     (doall (for [[coord row-size] (:min-row-sizes context)]
              (set-row-height! workbook coord row-size)))
     (doall (for [[coord col-size] (:min-col-sizes context)]
-            (set-col-width! workbook coord col-size)))
+             (set-col-width! workbook coord col-size)))
     (.write workbook output-stream)
     (.close workbook)
     {:workbook workbook :output-stream output-stream}))
@@ -159,4 +159,4 @@
 (defn write-xlsx! [cells path]
   (f/attempt-all [cells  (conform-cells cells)
                   result (f/try* (throwable-write-xlsx! cells path))]
-    result))
+                 result))

--- a/test/zero_one/fxl/core_test.clj
+++ b/test/zero_one/fxl/core_test.clj
@@ -1,13 +1,13 @@
 (ns zero-one.fxl.core-test
   (:require
-    [clojure.java.io :as io]
-    [clojure.spec.alpha :as s]
-    [midje.sweet :refer [facts fact =>]]
-    [zero-one.fxl.specs :as fs]
-    [zero-one.fxl.core :as fxl])
+   [clojure.java.io :as io]
+   [clojure.spec.alpha :as s]
+   [midje.sweet :refer [facts fact =>]]
+   [zero-one.fxl.specs :as fs]
+   [zero-one.fxl.core :as fxl])
   (:import
-    [java.io File FileOutputStream]
-    [org.apache.poi.xssf.usermodel XSSFWorkbook]))
+   [java.io File FileOutputStream]
+   [org.apache.poi.xssf.usermodel XSSFWorkbook]))
 
 (facts "On fxl/read-xlsx"
   (let [cells   (fxl/read-xlsx! "test/resources/dummy-spreadsheet.xlsx")
@@ -22,8 +22,8 @@
       (contains? (->> styles (map :font-size) set) 14) => true)
     (fact "Border style should be extracted"
       (contains?
-        (->> styles (map :bottom-border) set)
-        {:style :thin :colour :black1}) => true)
+       (->> styles (map :bottom-border) set)
+       {:style :thin :colour :black1}) => true)
     (fact "Alignment style should be extracted"
       (contains? (->> styles (map :vertical) set) :center) => true)
     (fact "Data formats should be extracted"

--- a/test/zero_one/fxl/errors_test.clj
+++ b/test/zero_one/fxl/errors_test.clj
@@ -1,9 +1,9 @@
 (ns zero-one.fxl.errors-test
   (:require
-    [clojure.string :as str]
-    [failjure.core :as f]
-    [midje.sweet :refer [facts fact =>]]
-    [zero-one.fxl.core :as fxl]))
+   [clojure.string :as str]
+   [failjure.core :as f]
+   [midje.sweet :refer [facts fact =>]]
+   [zero-one.fxl.core :as fxl]))
 
 (defmacro with-out-str-and-value
   ; Source: https://stackoverflow.com/questions/7150776/capturing-the-original-return-value-from-with-out-str

--- a/test/zero_one/fxl/google_sheets_test.clj
+++ b/test/zero_one/fxl/google_sheets_test.clj
@@ -18,22 +18,22 @@
         @n-tries))))
 
 (facts "On exponential-backoff"
-       (gs/exponential-backoff {:wait-ms     100
-                                :growth-rate 2
-                                :max-ms      399
-                                :action!     (action-fn 0)}) => 1
-       (gs/exponential-backoff {:wait-ms     100
-                                :growth-rate 2
-                                :max-ms      399
-                                :action!     (action-fn 1)}) => 2
-       (gs/exponential-backoff {:wait-ms     100
-                                :growth-rate 2
-                                :max-ms      399
-                                :action!     (action-fn 2)}) => 3
-       (gs/exponential-backoff {:wait-ms     100
-                                :growth-rate 2
-                                :max-ms      399
-                                :action!     (action-fn 3)}) => (throws Exception))
+  (gs/exponential-backoff {:wait-ms     100
+                           :growth-rate 2
+                           :max-ms      399
+                           :action!     (action-fn 0)}) => 1
+  (gs/exponential-backoff {:wait-ms     100
+                           :growth-rate 2
+                           :max-ms      399
+                           :action!     (action-fn 1)}) => 2
+  (gs/exponential-backoff {:wait-ms     100
+                           :growth-rate 2
+                           :max-ms      399
+                           :action!     (action-fn 2)}) => 3
+  (gs/exponential-backoff {:wait-ms     100
+                           :growth-rate 2
+                           :max-ms      399
+                           :action!     (action-fn 3)}) => (throws Exception))
 
 (defn valid-credentials? []
   (try
@@ -46,13 +46,13 @@
   (defonce service (gs/sheets-service google-props))
 
   (facts "On gs/read-google-sheets!"
-         (let [spreadsheet-id "1_8g_ItFMIgpCMFIQ1L1CTRhF4oKsjTs4zYe0UMRSd-w"
-               sheet-names    (gs/sheet-names! service spreadsheet-id)
-               cells          (gs/read-google-sheets! service spreadsheet-id (first sheet-names))
-               values         (->> cells (map :value) set)]
-           (fact "Read cells should all be valid"
-                 (filter #(not (s/valid? ::fs/cell %)) cells) => ())
-           (fact "There should be 15 cells"
-                 (count cells) => 15)
-           (fact "Values should be extracted"
-                 (contains? values "1.4142") => true))))
+    (let [spreadsheet-id "1_8g_ItFMIgpCMFIQ1L1CTRhF4oKsjTs4zYe0UMRSd-w"
+          sheet-names    (gs/sheet-names! service spreadsheet-id)
+          cells          (gs/read-google-sheets! service spreadsheet-id (first sheet-names))
+          values         (->> cells (map :value) set)]
+      (fact "Read cells should all be valid"
+        (filter #(not (s/valid? ::fs/cell %)) cells) => ())
+      (fact "There should be 15 cells"
+        (count cells) => 15)
+      (fact "Values should be extracted"
+        (contains? values "1.4142") => true))))

--- a/test/zero_one/fxl/helpers_test.clj
+++ b/test/zero_one/fxl/helpers_test.clj
@@ -1,10 +1,10 @@
 (ns zero-one.fxl.helpers-test
   (:require
-    [clojure.spec.alpha :as s]
-    [midje.sweet :refer [facts fact =>]]
-    [zero-one.fxl.specs :as fs]
-    [zero-one.fxl.core :as fxl]
-    [zero-one.fxl.defaults :as defaults]))
+   [clojure.spec.alpha :as s]
+   [midje.sweet :refer [facts fact =>]]
+   [zero-one.fxl.specs :as fs]
+   [zero-one.fxl.core :as fxl]
+   [zero-one.fxl.defaults :as defaults]))
 
 (facts "On fxl/->cell"
   (fact "Should fill-in the blanks"
@@ -115,7 +115,6 @@
                                         (every? vector? %))
       (fxl/cells->table cells "Sheet1") => table
       (fxl/cells->table cells "Sheet2") => empty?)))
-
 
 (facts "On fxl/records->table and fxl/records->cells"
   (let [records [{:item "Rent" :cost 1000}

--- a/test/zero_one/fxl/specs_test.clj
+++ b/test/zero_one/fxl/specs_test.clj
@@ -1,8 +1,8 @@
 (ns zero-one.fxl.specs-test
   (:require
-    [clojure.string :refer [includes?]]
-    [midje.sweet :refer [facts fact =>]]
-    [zero-one.fxl.specs :as fs]))
+   [clojure.string :refer [includes?]]
+   [midje.sweet :refer [facts fact =>]]
+   [zero-one.fxl.specs :as fs]))
 
 (facts "On valid? and invalid?"
   (fact "Should give correct results"

--- a/test/zero_one/fxl/write_xlsx_test.clj
+++ b/test/zero_one/fxl/write_xlsx_test.clj
@@ -1,9 +1,9 @@
 (ns zero-one.fxl.write-xlsx-test
   (:require
-    [midje.sweet :refer [facts fact =>]]
-    [zero-one.fxl.write-xlsx :as write-xlsx])
+   [midje.sweet :refer [facts fact =>]]
+   [zero-one.fxl.write-xlsx :as write-xlsx])
   (:import
-    (org.apache.poi.xssf.usermodel XSSFWorkbook)))
+   (org.apache.poi.xssf.usermodel XSSFWorkbook)))
 
 (def example-cells
   [{:value "X" :coord {:row 0 :col 0} :style {:row-size 1 :col-size 9}}


### PR DESCRIPTION
Keep the style consistent via the common formatter

- Add lein-cljfmt as plugins with basic rules like in Geni
- Run the formatter through the project